### PR TITLE
ci(github-action): Add action to compress image on push event to themain branch

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yaml
+++ b/.github/workflows/calibreapp-image-actions.yaml
@@ -1,0 +1,31 @@
+name: Compress Images
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: calibreapp/image-actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Compress Images
+        uses: calibreapp/image-actions@main
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          # For non-Pull Requests, run in compressOnly mode and we'll PR after.
+          compressOnly: ${{ github.event_name != 'pull_request' }}
+
+      - name: Create Pull Request
+        # If it's not a Pull Request then commit any changes as a new PR.
+        # Enable access permission for GitHub Action to create pull requests.
+        # For info, check https://stackoverflow.com/questions/72376229/github-actions-is-not-permitted-to-create-or-approve-pull-requests-createpullre
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Auto Compress Images
+          branch-suffix: timestamp
+          commit-message: Compress Images
+          body: ${{ steps.calibre.outputs.markdown }}


### PR DESCRIPTION
## Please, go through these steps before you submit a PR.

- [X] My Pod Leader knows I'm working on this Pull Request
- [X] I've explained what the Pull Request is adding.
- [X] I've explained why this is important.

closes #2 

This tool makes it easy to compress images and reduce their file size, which in turn improves website performance by decreasing page load times. The calibreapp/image-actions@main action is used in the workflow, but it only works for pull requests from branches in the same repository as the destination branch. This is because GitHub Actions do not have permission to modify forked repositories by default.

To address this limitation, we modified the GitHub Action to only execute on push events to the main branch. We also added a step to create a pull request for the compressed image file whenever a push event occurs on the main branch. However, in order for this step to work, access permissions must be enabled for the GitHub Action to create pull requests. For more information on enabling this feature, please see https://stackoverflow.com/questions/72376229/github-actions-is-not-permitted-to-create-or-approve-pull-requests-createpullre.

