### PR TITLE
Social handles added for fellows

### DIFF
--- a/_data/fellows.yml
+++ b/_data/fellows.yml
@@ -1,77 +1,9 @@
-- name: "Aksh Gupta"
-  title: "Aksh Gupta"
-  github: akshgpt7
-  location: "Delhi, India"
-  university: "JIIT, Noida"
-  about: "Always looking to expand my horizons and try out new things."	
-  languages: "Python"
-  hobbies: "Making Music"
-  img: "/assets/img/fellows/aksh.jpg"
-
-- name: "Tomas Ortin"
-  title: "Tomas Ortin"
-  github: ttn-ttn
-  location: "Sant Celoni, Spain"
-  university: "University of London"
-  about: "I'm passionate about programming language theory, compilers and interpreters. Graduate in Asian Cultural studies, currently a freshman in Computer Science. Notice the breath, relax and smile!"	
-  languages: "Scheme, C"
-  hobbies: "Hiking, reading"
-  img: "/assets/img/fellows/tomas.jpg"
-
-- name: "Priyanka R."
-  title: "Priyanka R."
-  github: ohsweetmani
-  location: "New Jersey, USA"
-  university: "University of Massachusetts"
-  about: "I'm a 3rd year studying at University of Massachusetts majoring in IT. Outside of classes and programming, I enjoy art. I have run an Art Club and been drawing for over the past 10 years. I prefer traditional mediums, specifically watercolor and charcoal."	
-  languages: "Java and Python"
-  hobbies: "Art and cooking. "
-  img: "/assets/img/fellows/priyanka.png"
-
-- name: "Mamtha Patalay"
-  title: "Mamtha Patalay"
-  github: suppixie
-  location: "Hyderabad, India"
-  university: "Institute of Aeronautical Engineering"
-  about: "Hey, I'm Mamtha. I love using my imagination and creativity to make beautiful Websites. Passionate about Art "	
-  languages: "Python, javascript"
-  hobbies: "Art, watching movies, listening to music"
-  img: "/assets/img/fellows/mamtha.jpg"
-
-- name: "Josh"
-  title: "Josh"
-  github: thatjosh
-  location: "London, UK"
-  university: "London School of Economics (LSE)"
-  about: "Aspiring software engineer."	
-  languages: "TypeScript, Python, C"
-  hobbies: "Bouldering, Binging Netflix, Playing poker card games"
-  img: "/assets/img/fellows/josh.png"
-
-- name: "Jessie Lin"
-  title: "Jessie Lin"
-  github: jessielin34
-  location: "New York, USA"
-  university: "Hunter College"
-  about: "Hello, my name's Jessie. I love listening to music and is very interested in learning new things everyday "	
-  languages: "Python and C++"
-  hobbies: "Listening to music"
-  img: "/assets/img/fellows/jessie.jpg"
-
-- title: "Ikeh Akinyemi"
-  name: "Ikeh Akinyemi"
-  github: ikehakinyemi
-  location: "Port Harcourt, Nigeria"
-  university: "University Of Port Harcourt"
-  about: "I'm a Software Engineer, in love with Pure and Applied Mathematics and a knack for problem-solving."	
-  languages: "Go, Rust, TypeScript and Python"
-  hobbies: "Video games, travelling."
-  img: "/assets/img/fellows/ikeh.JPG"
-  
-  
 - title: "Abirami Karthikeyan"
   name: "Abirami Karthikeyan"
   github: k-abirami
+  linkedin: abirami-karthikeyan
+  resume:
+  twitter:
   location: "Toronto, Canada"
   university: "University of Waterloo"
   about: "Hey! I'm Abirami and I'm a second year computer science student at the University of Waterloo. I like exploring new technologies and learning new things. I'm excited to be here and am looking forward to getting to know other people!"	
@@ -79,9 +11,52 @@
   hobbies: "Watching Netflix and Baking"
   img: "/assets/img/fellows/abirami.jpg"
 
+- title: "Akansha Sakhre"
+  name: "Akansha Sakhre"
+  github: akanshaaa19
+  linkedin:
+  resume:
+  twitter:
+  location: "Bhopal, India"
+  url: "/akansha"
+  university: "Mits, Gwalior"
+  about: "I'm a third-year computer science student with a keen interest in front-end development. I enjoy learning new things and taking on new challenges. Along with all of this, I enjoy participating in hackathons, networking with new people,"	
+  languages: "JavaScript and Python"
+  hobbies: "Binge watching dramas"
+  img: "/assets/img/fellows/akansha.jpg"
+
+- name: "Aksh Gupta"
+  title: "Aksh Gupta"
+  github: akshgpt7
+  linkedin: aksh-gupta
+  resume:
+  twitter:
+  location: "Delhi, India"
+  university: "JIIT, Noida"
+  about: "Always looking to expand my horizons and try out new things."	
+  languages: "Python"
+  hobbies: "Making Music"
+  img: "/assets/img/fellows/aksh.jpg"
+
+- title: "Ankur Agarwal"
+  name: "Ankur Agarwal"
+  github: Ankur6702
+  linkedin: ankur-8
+  resume: https://drive.google.com/file/d/1MyCnmqdVxnRRXukGC67sClzkFOTAgbKU/view?usp=sharing
+  twitter: _Ankur_Agarwal_
+  location: "Aligarh, India"
+  university: "Indian Institute of Information Technology Kota "
+  about: "Talks about Development, Linux, Community | MLH Prep Fellow'23 | Google DSC Lead'22 | Microsoft Learn Student Ambassador | MERN Stack Developer | Devops 🚀"	
+  languages: "Javascript, C++ and python"
+  hobbies: "Listening songs, playing piano and networking talks."
+  img: "/assets/img/fellows/Ankur.jpg"
+
 - title: "Archi Kirar"
   name: "Archi Kirar"
   github: archikirar30
+  linkedin: archi-kirar-a7b616247
+  resume: https://docs.google.com/document/d/1rpMuNxNYZw5kTG6R9FeKcBS3eN9WPFK9/edit?usp=drivesdk&ouid=105170070450477059090&rtpof=true&sd=true
+  twitter:
   location: "Bhopal, India"
   university: "Sage University bhopal"
   about: "I'm a Btech CSE hons second year student. I have passion of technology to boost my skills and experience."	
@@ -92,6 +67,9 @@
 - title: "Daniel Yu"
   name: "Daniel Yu"
   github: thgreatexplorer
+  linkedin: daniel-yu-693a93172
+  resume:
+  twitter:
   location: "New York, USA"
   university: "Northeastern University"
   about: "Hi, this is Daniel. I'm an ambitious and driven college student pursuing a Math and Computer Science combined Bachelor's degree at Northeastern University. I'm an active member of my school's Electric Car Racing team, Student Investment Fund, and am interested in software engineering, data analytics, and quantitative finance."	
@@ -99,9 +77,64 @@
   hobbies: "Exercising, listening to music"
   img: "/assets/img/fellows/Daniel.jpg"
 
+- title: "Ikeh Akinyemi"
+  name: "Ikeh Akinyemi"
+  github: ikehakinyemi
+  linkedin: ikeh-chukwuka
+  resume: https://docs.google.com/document/d/1-_BOAbj88vG1KiijWeNh9ui13mJNtDV-/edit
+  twitter: IkehAkinyemi
+  location: "Port Harcourt, Nigeria"
+  university: "University Of Port Harcourt"
+  about: "I'm a Software Engineer, in love with Pure and Applied Mathematics and a knack for problem-solving."	
+  languages: "Go, Rust, TypeScript and Python"
+  hobbies: "Video games, travelling."
+  img: "/assets/img/fellows/ikeh.JPG"
+
+- title: "Jay Gala"
+  name: "Jay Gala"
+  github: jaygala223
+  linkedin: jaykishorgala
+  resume: https://drive.google.com/drive/folders/1jphVh04iyyQFjqodlwrbyoZjvfQnjAX9?usp=share_link
+  twitter: jaygala223
+  location: "Mumbai, India"
+  university: "NMIMS University, Mumbai"
+  about: "I am a pre-final year CSE and MBA student at NMIMS Mumbai. I have worked as an intern at GeeksforGeeks, Conbi, Transparent Capital and Analytica. I also regularly contribute code to open source projects like Mozilla Firefox, TensorFlow, Ivy and Keras. I am also a TensorFlow Certified Developer and the Co-Founder of Codechef Mpstme Chapter."	
+  languages: "Python and C++"
+  hobbies: "Fitness, Chess and Reading (currently reading Harry Potter and the Order of the Phoenix)"
+  img: "/assets/img/fellows/Jay.jpg"
+
+- name: "Jessie Lin"
+  title: "Jessie Lin"
+  github: jessielin34
+  linkedin: jessie-lin-0273631b2
+  resume: https://docs.google.com/document/d/1cplw2fwCCuYi3eJdbeNZ8dVPg1brIat1/edit
+  twitter:
+  location: "New York, USA"
+  university: "Hunter College"
+  about: "Hello, my name's Jessie. I love listening to music and is very interested in learning new things everyday "	
+  languages: "Python and C++"
+  hobbies: "Listening to music"
+  img: "/assets/img/fellows/jessie.jpg"
+
+- name: "Josh"
+  title: "Josh"
+  github: thatjosh
+  linkedin: joshuaangzhiyuan
+  resume:
+  twitter:
+  location: "London, UK"
+  university: "London School of Economics (LSE)"
+  about: "Aspiring software engineer."	
+  languages: "TypeScript, Python, C"
+  hobbies: "Bouldering, Binging Netflix, Playing poker card games"
+  img: "/assets/img/fellows/josh.png"
+
 - title: "Kristin Lam"
   name: "Kristin Lam"
   github: kristinlam
+  linkedin:
+  resume:
+  twitter:
   location: "New York, USA"
   university: "Villanova University"
   about: "I'm Kristin and I love creating things on the web. After graduating with a degree in Computer Science, I designed and developed webpages and emails for a homeless nonprofit, followed by a cancer treatment and research institution. I'm passionate about sustainability, mental health, and equality and diversity, and have always found fulfillment in using my technical skills to help others. To level up my skills, I attended The Grace Hopper Coding Bootcamp. Now, I’m ready to make a difference as a software engineer."	
@@ -112,6 +145,9 @@
 - title: "Lakshya Gupta"
   name: "Lakshya Gupta"
   github: void-ness
+  linkedin: lakshya-gupta-01
+  resume:
+  twitter:
   location: "Delhi, India"
   university: "Bharati Vidyapeeth's College of Engineering"
   about: "Web Developer by day, Blockchain Enthusiast by night. I am a part-time engineer and a full-time tech lover. Life is too short, just checkmate and move on."	
@@ -119,33 +155,41 @@
   hobbies: "Chess & Hip Hop music"
   img: "/assets/img/fellows/lakshya.jpg"
 
-- title: "Akansha Sakhre"
-  name: "Akansha Sakhre"
-  github: akanshaaa19
-  location: "Bhopal, India"
-  url: "/akansha"
-  university: "Mits, Gwalior"
-  about: "I'm a third-year computer science student with a keen interest in front-end development. I enjoy learning new things and taking on new challenges. Along with all of this, I enjoy participating in hackathons, networking with new people,"	
-  languages: "JavaScript and Python"
-  hobbies: "Binge watching dramas"
-  img: "/assets/img/fellows/akansha.jpg"
+- name: "Mamtha Patalay"
+  title: "Mamtha Patalay"
+  github: suppixie
+  linkedin: mamtha-patalay
+  resume: https://docs.google.com/document/d/1psPQEImDkWvNjg-xhZxRDrUPl17-QgCtNda6Wh0erJQ/edit
+  twitter: mamtha_6
+  location: "Hyderabad, India"
+  university: "Institute of Aeronautical Engineering"
+  about: "Hey, I'm Mamtha. I love using my imagination and creativity to make beautiful Websites. Passionate about Art "	
+  languages: "Python, javascript"
+  hobbies: "Art, watching movies, listening to music"
+  img: "/assets/img/fellows/mamtha.jpg"
 
-- title: "Ankur Agarwal"
-  name: "Ankur Agarwal"
-  github: ankur6702
-  location: "Aligarh, India"
-  university: "Indian Institute of Information Technology Kota "
-  about: "Talks about Development, Linux, Community | MLH Prep Fellow'23 | Google DSC Lead'22 | Microsoft Learn Student Ambassador | MERN Stack Developer | Devops 🚀"	
-  languages: "Javascript, C++ and python"
-  hobbies: "Listening songs, playing piano and networking talks."
-  img: "/assets/img/fellows/Ankur.jpg"
+- name: "Priyanka R."
+  title: "Priyanka R."
+  github: ohsweetmani
+  linkedin:
+  resume:
+  twitter:
+  location: "New Jersey, USA"
+  university: "University of Massachusetts"
+  about: "I'm a 3rd year studying at University of Massachusetts majoring in IT. Outside of classes and programming, I enjoy art. I have run an Art Club and been drawing for over the past 10 years. I prefer traditional mediums, specifically watercolor and charcoal."	
+  languages: "Java and Python"
+  hobbies: "Art and cooking. "
+  img: "/assets/img/fellows/priyanka.png"
 
-- title: "Jay Gala"
-  name: "Jay Gala"
-  github: jaygala223
-  location: "Mumbai, India"
-  university: "NMIMS University, Mumbai"
-  about: "I am a pre-final year CSE and MBA student at NMIMS Mumbai. I have worked as an intern at GeeksforGeeks, Conbi, Transparent Capital and Analytica. I also regularly contribute code to open source projects like Mozilla Firefox, TensorFlow, Ivy and Keras. I am also a TensorFlow Certified Developer and the Co-Founder of Codechef Mpstme Chapter."	
-  languages: "Python and C++"
-  hobbies: "Fitness, Chess and Reading (currently reading Harry Potter and the Order of the Phoenix)"
-  img: "/assets/img/fellows/Jay.jpg"
+- name: "Tomas Ortin"
+  title: "Tomas Ortin"
+  github: ttn-ttn
+  linkedin:
+  resume:
+  twitter:
+  location: "Sant Celoni, Spain"
+  university: "University of London"
+  about: "I'm passionate about programming language theory, compilers and interpreters. Graduate in Asian Cultural studies, currently a freshman in Computer Science. Notice the breath, relax and smile!"	
+  languages: "Scheme, C"
+  hobbies: "Hiking, reading"
+  img: "/assets/img/fellows/tomas.jpg"

--- a/_includes/description.html
+++ b/_includes/description.html
@@ -8,13 +8,13 @@
           <p class="title"> {{ fellow.name }}</p>
           <p class="location"> {{ fellow.location }}</p>
           <div class="socials">
-            <a href="{{ fellow.linkedin | relative_url }}" target="_blank">
+            <a href="https://linkedin.com/in/{{ fellow.linkedin }}" target="_blank">
               <img src="assets/img/icons8-linkedin-circled-2.gif" alt="Linkedin" loading="lazy" class="socicon" />
             </a>
-            <a href="{{ fellow.twitter | relative_url }}" target="_blank">
+            <a href="https://twitter.com/{{ fellow.twitter }}" target="_blank">
               <img src="assets/img/icons8-twitter.gif" alt="Twitter" loading="lazy" class="socicon" />
             </a>
-            <a href="{{ fellow.github | relative_url }}" target="_blank">
+            <a href="https://github.com/{{ fellow.github }}" target="_blank">
               <img src="assets/img/icons8-github.gif" alt="Github" loading="lazy" class="socicon" />
             </a>
             <a href="{{ fellow.resume | relative_url }}" target="_blank">


### PR DESCRIPTION
Fixes #40 
- Added social handle URLs of all the fellows who shared their social links.
- Sorted all fellows in ascending order (which I guess was a better way to present the information)

@akshgpt7 please review the PR. Let me know if it require any changes.